### PR TITLE
Use stdlib.h instead of malloc.h

### DIFF
--- a/libxml2.go
+++ b/libxml2.go
@@ -6,7 +6,7 @@ package xsdvalidate
 #include <string.h>
 #include <libxml/xmlschemastypes.h>
 #include <errno.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #define GO_ERR_INIT 1024
 #define P_ERR_DEFAULT 1


### PR DESCRIPTION
# Summary
`malloc.h` as a header for [`libxml2.go#L9`](https://github.com/terminalstatic/go-xsd-validate/blob/master/libxml2.go#L9) looks to be non-standard outside of linux builds and fails when compiling in an OS X environment.

Almost all the malloc functionality is exposed through `stdlib.h` and it looks like we're using all the standard functions. So instead we can use that here.

# Investigation

Initially trying to use this package on OS X led to some odd compilation errors with the environment.
```
$ go vet
# github.com/terminalstatic/go-xsd-validate
../../../../go/pkg/mod/github.com/terminalstatic/go-xsd-validate@v0.1.2/libxml2.go:7:10: fatal error: 'libxml/xmlschemastypes.h' file not found
#include <libxml/xmlschemastypes.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This was fixed with suggestions about [installing the headers in a way that was pre-OS X 10.14](https://silvae86.github.io/sysadmin/mac/osx/mojave/beta/libxml2/2018/07/05/fixing-missing-headers-for-homebrew-in-mac-osx-mojave/) instead of relying on `xcode-select --install` for the correct linkages.

However, there was still this compilation error:

```
$ go build xsdvalidate 
# xsdvalidate
./libxml2.go:9:10: fatal error: 'malloc.h' file not found
#include <malloc.h>
         ^~~~~~~~~~
1 error generated.
```

And investigating led to an oddity in the Mac environment where malloc.h is not a top-level package.

```
$ find / | grep malloc.h
  ...
/usr/include/malloc/malloc.h
  ...
```

Options:
🚫 namespace this (`malloc/malloc.h` - still varies by environment ) 
✔️ use `stdlib.h` instead of `malloc.h` (the one implemented here)

# Solution
From [this SO answer](https://stackoverflow.com/a/12973361)
> The <malloc.h> header is deprecated (and quite Linux specific, on which it defines non-standard functions like mallinfo(3)). Use <stdlib.h> instead if you simply need malloc(3) and related standard functions (e.g. free, calloc, realloc ....). Notice that <stdlib.h> is defined by C89 (and later) standards, but not <malloc.h>

> stdlib.h is a standard C header that declares among other things the malloc(), calloc(), free() functions. This is the header you should include.

> malloc.h is a non-standard header, found on many systems where it often defines additional functions specific to the malloc implementation used by that platform.

it does not look like we are using any of the non-standard functions here and the tests build and pass correctly

```
$ go test -v ./...
=== RUN   Example
--- PASS: Example (0.00s)
PASS
ok      xsdvalidate     0.007s
```

# References:

- https://silvae86.github.io/sysadmin/mac/osx/mojave/beta/libxml2/2018/07/05/fixing-missing-headers-for-homebrew-in-mac-osx-mojave/
- https://stackoverflow.com/a/12973361
- https://stackoverflow.com/a/56463133
