### PR TITLE
Add function for instantiating xsdHandler from memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Go get the package:
 	go get github.com/terminalstatic/go-xsd-validate
 	
 # Examples
-Check [this](./examples/_server/simple/simple.go) for a simple http server example and [that](./examples/_server/simpler/simpler.go) for an even simpler one.
+Check [this](./examples/_server/simple/simple.go) for a simple http server example and [that](./examples/_server/simpler/simpler.go) for an even simpler one. Look at [this](./examples/_server/simpler_mem/simpler_mem.go) for an example using Go's `embed` package to bake an XML schema into a simple http server.
 To see how this could be plugged into middleware see the [go-chi](https://github.com/go-chi/chi) [example](./examples/_server/chi/chi.go) I came up with. 
 
 ```go

--- a/examples/_server/simpler_mem/address.xml
+++ b/examples/_server/simpler_mem/address.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<address>
+    <street>Orchardroad</street>
+    <street-number>15</street-number>
+    <city>Uusikaupunki</city>
+    <zip>1313</zip>
+    <country>Farawayistan</country>
+</address>

--- a/examples/_server/simpler_mem/address.xsd
+++ b/examples/_server/simpler_mem/address.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:element name="address">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="street" type="xs:string"/>
+            <xs:element name="street-number" type="xs:string"/>
+            <xs:element name="city" type="xs:string"/>
+            <xs:element name="zip" type="xs:string"/>
+            <xs:element name="country" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+</xs:schema>

--- a/examples/_server/simpler_mem/simpler_mem.go
+++ b/examples/_server/simpler_mem/simpler_mem.go
@@ -1,0 +1,56 @@
+// A simpler standalone example for xsd validation and http
+package main
+
+import (
+	_ "embed"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/terminalstatic/go-xsd-validate"
+)
+
+//go:embed address.xsd
+var xsd []byte
+
+var xsdHandler *xsdvalidate.XsdHandler
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("content-type", "application/xml; charset=utf-8")
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Fprintf(w, fmt.Sprintf("%s<error><![CDATA[%s]]></error>", xml.Header, err))
+		return
+	}
+
+	err = xsdHandler.ValidateMem(body, xsdvalidate.ParsErrVerbose)
+	if err != nil {
+		fmt.Fprintf(w, fmt.Sprintf("%s<error><![CDATA[%s]]></error>", xml.Header, err))
+		return
+	}
+
+	fmt.Fprintf(w, fmt.Sprintf("%s<no-error>No errors</no-error>", xml.Header))
+}
+
+func main() {
+	addr := ":9999"
+	xsdvalidate.Init()
+	defer xsdvalidate.Cleanup()
+	var err error
+	xsdHandler, err = xsdvalidate.NewXsdHandlerMem(xsd, xsdvalidate.ParsErrDefault)
+	defer xsdHandler.Free()
+	if err != nil {
+		panic(err)
+	}
+
+	http.HandleFunc("/xsd", handler)
+	fmt.Printf("Starting http server on %s\n", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/libxml2.go
+++ b/libxml2.go
@@ -454,8 +454,8 @@ func parseUrlSchema(url string, options Options) (C.xmlSchemaPtr, error) {
 	return pRes.schemaPtr, nil
 }
 
-// The helper function for setting up an in-memory xsd source
-func formXsdSchema(xsd []byte, options Options) (C.xmlSchemaPtr, error) {
+// The helper function for parsing an in-memory schema
+func parseMemSchema(xsd []byte, options Options) (C.xmlSchemaPtr, error) {
 	strXsd := C.CBytes(xsd)
 	defer C.free(unsafe.Pointer(strXsd))
 

--- a/validate_xsd.go
+++ b/validate_xsd.go
@@ -109,7 +109,7 @@ func NewXsdHandlerUrl(url string, options Options) (*XsdHandler, error) {
 	return &XsdHandler{sPtr}, err
 }
 
-// NewXsdhandlerString creates an xsd handler struct.
+// NewXsdHandlerMem creates an xsd handler struct.
 // Always use Free() method when done using this handler or memory will leak.
 // If an error is returned it can be of type Libxml2Error or XsdParserError.
 // The go garbage collector will not collect the allocated resources.

--- a/validate_xsd.go
+++ b/validate_xsd.go
@@ -109,6 +109,20 @@ func NewXsdHandlerUrl(url string, options Options) (*XsdHandler, error) {
 	return &XsdHandler{sPtr}, err
 }
 
+// NewXsdhandlerString creates an xsd handler struct.
+// Always use Free() method when done using this handler or memory will leak.
+// If an error is returned it can be of type Libxml2Error or XsdParserError.
+// The go garbage collector will not collect the allocated resources.
+func NewXsdHandlerMem(inSchema []byte, options Options) (*XsdHandler, error) {
+	g.Lock()
+	defer g.Unlock()
+	if !g.isInitialized() {
+		return nil, Libxml2Error{errorMessage{"Libxml2 not initialized"}}
+	}
+	sPtr, err := formXsdSchema(inSchema, options)
+	return &XsdHandler{sPtr}, err
+}
+
 // Validate validates an xmlHandler against an xsdHandler and returns a ValidationError.
 // If an error is returned it is of type Libxml2Error, XsdParserError, XmlParserError or ValidationError.
 // Both xmlHandler and xsdHandler have to be created first.

--- a/validate_xsd.go
+++ b/validate_xsd.go
@@ -119,7 +119,7 @@ func NewXsdHandlerMem(inSchema []byte, options Options) (*XsdHandler, error) {
 	if !g.isInitialized() {
 		return nil, Libxml2Error{errorMessage{"Libxml2 not initialized"}}
 	}
-	sPtr, err := formXsdSchema(inSchema, options)
+	sPtr, err := parseMemSchema(inSchema, options)
 	return &XsdHandler{sPtr}, err
 }
 


### PR DESCRIPTION
Function NewXsdHandlerMem creates an xsdHandler using a byte array
rather than using a URL.

This is useful for dynamic XSD sources, or for bundling XML definitions
using e.g., the embed package.

I tested it with some XML and an XSD I had in my project, and it seemed 
to work - it hasn't been "stress tested" or anything, and my C experience is 
pretty limited, but it effectively is just a version of the NewXsdHandlerUrl 
adapted to use the libxml in-memory equivalent:

http://xmlsoft.org/html/libxml-xmlschemas.html#xmlSchemaNewMemParserCtxt

Thank you for the very nice project, and I hope this is useful.