### PR TITLE
Fix libxml2 warnings

### DIFF
--- a/libxml2.go
+++ b/libxml2.go
@@ -192,7 +192,6 @@ static void simpleStructErrorCallback(
 static struct xsdParserResult parseSchema(
                                           xmlSchemaParserCtxtPtr schemaParserCtxt,
                                           const short int options) {
-    xmlLineNumbersDefault(1);
     bool err = false;
     struct xsdParserResult parserResult;
     errCtx ectx = initErrCtx(1, GO_ERR_INIT);
@@ -253,7 +252,6 @@ static struct xsdParserResult cParseMemSchema(const void* xsd,
 static struct xmlParserResult cParseDoc(const void* goXmlSource,
                                         const int goXmlSourceLen,
                                         const short int options) {
-    xmlLineNumbersDefault(1);
     bool err = false;
     struct xmlParserResult parserResult;
     errCtx ectx = initErrCtx(1, GO_ERR_INIT);
@@ -284,7 +282,7 @@ static struct xmlParserResult cParseDoc(const void* goXmlSource,
                 xmlSetGenericErrorFunc(NULL, noOutputCallback);
             }
 
-            doc = xmlParseMemory(goXmlSource, goXmlSourceLen);
+            doc = xmlReadMemory(goXmlSource, goXmlSourceLen, NULL, NULL, 0);
 
             xmlFreeParserCtxt(xmlParserCtxt);
             if (doc == NULL) {
@@ -306,8 +304,6 @@ static struct xmlParserResult cParseDoc(const void* goXmlSource,
 }
 
 static errArray cValidate(const xmlDocPtr doc, const xmlSchemaPtr schema) {
-    xmlLineNumbersDefault(1);
-
     errArray errArr = initErrArray();
 
     struct simpleXmlError simpleError;
@@ -359,8 +355,6 @@ static errArray cValidateBuf(const void* goXmlSource,
                              const int goXmlSourceLen,
                              const short int xmlParserOptions,
                              const xmlSchemaPtr schema) {
-    xmlLineNumbersDefault(1);
-
     errArray errArr = initErrArray();
 
     struct simpleXmlError simpleError;

--- a/libxml2.go
+++ b/libxml2.go
@@ -113,7 +113,9 @@ static void init() {
 }
 
 static void cleanup() {
+#if LIBXML_VERSION < 21000
     xmlSchemaCleanupTypes();
+#endif
     xmlCleanupParser();
 }
 

--- a/libxml2.go
+++ b/libxml2.go
@@ -141,7 +141,14 @@ static void genErrorCallback(void* ctx, const char* message, ...) {
     free(newLine);
 }
 
-static void simpleStructErrorCallback(void* ctx, xmlErrorPtr p) {
+static void simpleStructErrorCallback(
+    void* ctx,
+#if LIBXML_VERSION >= 21200
+    const xmlError *p
+#else
+    xmlErrorPtr p
+#endif
+) {
     errArray* sErrArr = ctx;
 
     struct simpleXmlError sErr;


### PR DESCRIPTION
Every commit has detailed description.

I've tested this on Docker images `golang:1.22-bullseye` (libxml2 2.9.10), `golang:1.22-bookworm` (libxml2 2.9.14), and on my own system (libxml2 2.12.6).

Closes #19