### PR TITLE
ParsXmlHuge flag to support large XML files

### DIFF
--- a/libxml2.go
+++ b/libxml2.go
@@ -13,6 +13,7 @@ package xsdvalidate
 #define GO_ERR_INIT 1024
 #define P_ERR_DEFAULT 1
 #define P_ERR_VERBOSE 2
+#define P_XML_HUGE 4
 #define LIBXML_STATIC
 #define NOOP ((void)0)
 
@@ -249,6 +250,16 @@ static struct xsdParserResult cParseMemSchema(const void* xsd,
     return parseSchema(schemaParserCtxt, options);
 }
 
+static int getLibxmlOptions(short int options) {
+    int xmlParserOptions = 0;
+
+    if (options & P_XML_HUGE) {
+        xmlParserOptions |= XML_PARSE_HUGE;
+    }
+
+    return xmlParserOptions;
+}
+
 static struct xmlParserResult cParseDoc(const void* goXmlSource,
                                         const int goXmlSourceLen,
                                         const short int options) {
@@ -282,7 +293,8 @@ static struct xmlParserResult cParseDoc(const void* goXmlSource,
                 xmlSetGenericErrorFunc(NULL, noOutputCallback);
             }
 
-            doc = xmlReadMemory(goXmlSource, goXmlSourceLen, NULL, NULL, 0);
+            int xmlParserOptions = getLibxmlOptions(options);
+            doc = xmlReadMemory(goXmlSource, goXmlSourceLen, NULL, NULL, xmlParserOptions);
 
             xmlFreeParserCtxt(xmlParserCtxt);
             if (doc == NULL) {

--- a/validate_xsd.go
+++ b/validate_xsd.go
@@ -1,6 +1,6 @@
 // Package xsdvalidate is a go package for xsd validation that utilizes libxml2.
 
-//The goal of this package is to preload xsd files into memory and to validate xml (fast) using libxml2, like post bodys of xml service endpoints or api routers. At the time of writing, similar packages I found on github either didn't provide error details or got stuck under load. In addition to providing error strings it also exposes some fields of libxml2 return structs.
+// The goal of this package is to preload xsd files into memory and to validate xml (fast) using libxml2, like post bodys of xml service endpoints or api routers. At the time of writing, similar packages I found on github either didn't provide error details or got stuck under load. In addition to providing error strings it also exposes some fields of libxml2 return structs.
 package xsdvalidate
 
 import "C"
@@ -40,6 +40,7 @@ type Options uint8
 const (
 	ParsErrDefault Options = 1 << iota // Default parser error output
 	ParsErrVerbose                     // Verbose parser error output, considerably slower!
+	ParsXmlHuge                        // Enable parsing of large XML
 )
 
 // Validation options for possible future enhancements.

--- a/validate_xsd_test.go
+++ b/validate_xsd_test.go
@@ -86,6 +86,27 @@ func TestXmlMemHandlerFail(t *testing.T) {
 	defer handler.Free()
 }
 
+func TestXmlMemHandlerLargeXml(t *testing.T) {
+	Init()
+	defer Cleanup()
+
+	xmlFilePass, err := os.Open("examples/huge_text_node.xml")
+	if err != nil {
+		fmt.Printf("Error: %s %s\n", t.Name(), err.Error())
+		return
+	}
+	defer xmlFilePass.Close()
+
+	inXml, _ := ioutil.ReadAll(xmlFilePass)
+
+	handler, err := NewXmlHandlerMem(inXml, ParsXmlHuge)
+	if err != nil {
+		fmt.Printf("Error: %s %s\n", t.Name(), err.Error())
+		t.Fail()
+	}
+	defer handler.Free()
+}
+
 func TestValidateWithXsdHandlerPass(t *testing.T) {
 	Init()
 	defer Cleanup()


### PR DESCRIPTION
This PR introduces a new option, ParsXmlHuge, to enable parsing large XML files by passing the XML_PARSE_HUGE flag to the underlying libxml2 parser. This helps handle long text nodes, and other large XML structures that exceed default limits.